### PR TITLE
Fix object hierarchy description

### DIFF
--- a/mixed-reality-docs/mr-learning-base-04.md
+++ b/mixed-reality-docs/mr-learning-base-04.md
@@ -100,7 +100,7 @@ ms.locfileid: "86305512"
 
 ![mr-learning-base](images/mr-learning-base/base-04-section4-step1-1.png)
 
-[Hierarchy]\(階層\) ウィンドウで、[RoverExplorer]、[RoverAssembly]、[RoverModel]、 **[Parts]\(パーツ\)** の子オブジェクトをすべて選択し、それらを右クリックして、 **[Duplicate]\(重複\)** を選択し、各パーツのコピーを作成します。
+[Hierarchy]\(階層\) ウィンドウで、[RoverExplorer] > [RoverAssembly] > [RoverModel] >  **[Parts]\(パーツ\)** の子オブジェクトをすべて選択し、それらを右クリックして、 **[Duplicate]\(重複\)** を選択し、各パーツのコピーを作成します。
 
 ![mr-learning-base](images/mr-learning-base/base-04-section4-step1-2.png)
 


### PR DESCRIPTION
Punctuation (、) is not appropriate to express hierarchy in Japanese.

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
